### PR TITLE
Feat/set local name baseurl

### DIFF
--- a/mailme.go
+++ b/mailme.go
@@ -71,7 +71,7 @@ func (m *Mailer) Mail(to, subjectTemplate, templateURL, defaultTemplate string, 
 	mail.SetBody("text/html", body)
 
 	dial := gomail.NewPlainDialer(m.Host, m.Port, m.User, m.Pass)
-	dial.LocalName = m.BaseURL
+	dial.LocalName = m.Host
 	return dial.DialAndSend(mail)
 
 }

--- a/mailme.go
+++ b/mailme.go
@@ -71,6 +71,7 @@ func (m *Mailer) Mail(to, subjectTemplate, templateURL, defaultTemplate string, 
 	mail.SetBody("text/html", body)
 
 	dial := gomail.NewPlainDialer(m.Host, m.Port, m.User, m.Pass)
+	dial.LocalName = m.BaseURL
 	return dial.DialAndSend(mail)
 
 }


### PR DESCRIPTION


## What kind of change does this PR introduce?

Bug fix:
- this fixes rejected emails by google gmail smtp relay services
- no localhost HELO message

## What is the current behavior?

GoMail uses localhost as HELO message which causes gmail smtp relay and other services to reject emails
[go mail behaviour](https://github.com/go-gomail/gomail/blob/81ebce5c23dfd25c6c67194b37d3dd3f338c98b1/smtp.go#L35)

Issue:
[supabase issue gmail smtp relay](https://github.com/supabase/supabase/issues/22296)

## What is the new behavior?

dialer now uses base url of project for HELO message which works instead of local host

non working HELO:
```
read R BLOCK
220 smtp-relay.gmail.com ESMTP m17-20020a5d6a11000000b0033e55077fd9sm4288wru.69 - gsmtp
helo localhost
421-4.7.0 Try again later, closing connection. (EHLO)
421-4.7.0  For more information, go to
421 4.7.0  https://support.google.com/a/answer/3221692 m17-20020a5d6a11000000b0033e55077fd9sm4288wru.69 - gsmtp
read:errno=0
```

working HELO:
```
read R BLOCK
220 smtp-relay.gmail.com ESMTP q16-20020a05600c46d000b004146a27d894sm24293wmo.31 - gsmtp
helo smtp-relay.gmail.com
250 smtp-relay.gmail.com at your service
```
## Additional context

Add any other context or screenshots.
