### PR TITLE
fix: expose the LocalName option in Mailer

### DIFF
--- a/mailme.go
+++ b/mailme.go
@@ -24,15 +24,16 @@ const TemplateExpiration = 10 * time.Second
 
 // Mailer lets MailMe send templated mails
 type Mailer struct {
-	From    string
-	Host    string
-	Port    int
-	User    string
-	Pass    string
-	BaseURL string
-	FuncMap template.FuncMap
-	cache   *TemplateCache
-	Logger  logrus.FieldLogger
+	From      string
+	Host      string
+	Port      int
+	User      string
+	Pass      string
+	BaseURL   string
+	LocalName string
+	FuncMap   template.FuncMap
+	cache     *TemplateCache
+	Logger    logrus.FieldLogger
 }
 
 // Mail sends a templated mail. It will try to load the template from a URL, and
@@ -71,7 +72,9 @@ func (m *Mailer) Mail(to, subjectTemplate, templateURL, defaultTemplate string, 
 	mail.SetBody("text/html", body)
 
 	dial := gomail.NewPlainDialer(m.Host, m.Port, m.User, m.Pass)
-	dial.LocalName = m.Host
+	if m.LocalName != "" {
+		dial.LocalName = m.LocalName
+	}
 	return dial.DialAndSend(mail)
 
 }

--- a/mailme.go
+++ b/mailme.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"html/template"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"strings"
@@ -71,7 +71,7 @@ func (m *Mailer) Mail(to, subjectTemplate, templateURL, defaultTemplate string, 
 	mail.SetHeader("Subject", subject.String())
 	mail.SetBody("text/html", body)
 
-	dial := gomail.NewPlainDialer(m.Host, m.Port, m.User, m.Pass)
+	dial := gomail.NewDialer(m.Host, m.Port, m.User, m.Pass)
 	if m.LocalName != "" {
 		dial.LocalName = m.LocalName
 	}
@@ -133,7 +133,7 @@ func (t *TemplateCache) fetchTemplate(url string, triesLeft int) (string, error)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode == 200 { // OK
-		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil && triesLeft > 0 {
 			return t.fetchTemplate(url, triesLeft-1)
 		}


### PR DESCRIPTION
## What kind of change does this PR introduce?
* The LocalName should be exposed so that we can set it as the supabase project domain / custom domain rather than making it default to the SMTP Host. Some SMTP servers may enforce that the LocalName can't be the same as the SMTP Host, although this is not strictly enforced across all providers (AWS SES and Resend seem to ignore this). 