### PR TITLE
feat: Allow for insecure servers

### DIFF
--- a/mailme.go
+++ b/mailme.go
@@ -2,6 +2,7 @@ package mailme
 
 import (
 	"bytes"
+	"crypto/tls"
 	"errors"
 	"html/template"
 	"io"
@@ -31,6 +32,7 @@ type Mailer struct {
 	Pass      string
 	BaseURL   string
 	LocalName string
+	Insecure  bool
 	FuncMap   template.FuncMap
 	cache     *TemplateCache
 	Logger    logrus.FieldLogger
@@ -72,6 +74,9 @@ func (m *Mailer) Mail(to, subjectTemplate, templateURL, defaultTemplate string, 
 	mail.SetBody("text/html", body)
 
 	dial := gomail.NewDialer(m.Host, m.Port, m.User, m.Pass)
+	if m.Insecure {
+		dial.TLSConfig = &tls.Config{InsecureSkipVerify: true}
+	}
 	if m.LocalName != "" {
 		dial.LocalName = m.LocalName
 	}


### PR DESCRIPTION
## What kind of change does this PR introduce?

This feature allows user to use insecure mail servers (i.e invalid TLS certificate) 

## What is the current behavior?

Currently, `mailme` doesn't send email triggering "x509: certificate signed by unknown authority" in logs.

## What is the new behavior?

The mail should now be sent if the user sets the boolean parameter `Insecure` to TRUE

## Additional context

This PR needs to be approved for PR https://github.com/supabase/auth/pull/1720 to be valid